### PR TITLE
Add GitHub Action to lint Python code with Ruff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -3,9 +3,9 @@
 name: ruff
 on:
   push:
-    branches: [master]
-  pull_request:
   #  branches: [master]
+  pull_request:
+    branches: [master]
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -3,7 +3,7 @@
 name: ruff
 on:
   push:
-  #  branches: [master]
+    branches: [master]
   pull_request:
     branches: [master]
 jobs:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+# https://github.com/codespell-project/codespell#readme
+# https://beta.ruff.rs
+name: ruff
+on:
+  push:
+    branches: [master]
+  pull_request:
+  #  branches: [master]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user codespell[toml] ruff
+    - run: codespell --quiet-level=3  # --ignore-words-list="" --skip="*.css,*.js,*.lock,*.po"
+    - run: ruff --format=github --ignore=F523 --line-length=113 --target-version=py37 .

--- a/synfo/package.py
+++ b/synfo/package.py
@@ -2,6 +2,7 @@ import os
 
 
 class Packages:
+
     def __init__(self):
         self.packages = self._get_packages()
 

--- a/synfo/package.py
+++ b/synfo/package.py
@@ -15,7 +15,7 @@ class Packages:
 
     @staticmethod
     def _get_packages():
-        """Retrieve a list of installed pacakges"""
+        """Retrieve a list of installed packages"""
         # Run pip freeze command
         pip_freeze = os.popen('pip freeze').read()
 


### PR DESCRIPTION
Test results: https://github.com/cclauss/synfo/actions

[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

The ruff Action uses minimal steps to run in ~5 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)